### PR TITLE
fix: add permissions to github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ jobs:
   build:
     name: 'Build Mindfire FOSS application'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: read
     steps:
       - name: 'Checkout repository'
         uses: actions/checkout@v2


### PR DESCRIPTION
Added the ci.yml file for building the project when code is pushed into the main branch.
Added write permission for contents in the github actions workflow