### PR TITLE
ci: add contributor-mapping.json to restore files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           git restore src/app/projects/assets/stats.json
           git restore src/app/projects/assets/packages.json
           git restore src/app/projects/assets/projects_grouped.json
+          git restore src/app/projects/assets/contributor-mapping.json
 
       - name: 'Fetch branches'
         run: git fetch origin


### PR DESCRIPTION
add contributor-mapping.json to restore files . When the build process modifies this file and then tries to checkout the gh-pages branch, Git refuses because the changes would be lost. fixed it by adding the json file in ci . 